### PR TITLE
준비 상태 집계 이벤트 추가 및 phase 전환 snapshot 동기화

### DIFF
--- a/src/game-state/interfaces/game-state-view.interface.ts
+++ b/src/game-state/interfaces/game-state-view.interface.ts
@@ -4,6 +4,7 @@ export interface RoomReadySummaryPayload {
   phase: GamePhase;
   readyCount: number;
   totalCount: number;
+  allReady: boolean;
 }
 
 export interface RoomPhasePlayerSnapshot {

--- a/src/game-state/interfaces/game-state-view.interface.ts
+++ b/src/game-state/interfaces/game-state-view.interface.ts
@@ -1,0 +1,25 @@
+import { GamePhase, type GameState } from './game-state.interface';
+
+export interface RoomReadySummaryPayload {
+  phase: GamePhase;
+  readyCount: number;
+  totalCount: number;
+}
+
+export interface RoomPhasePlayerSnapshot {
+  userId: number;
+  isReady: boolean;
+}
+
+export interface RoomPhaseSnapshotPayload {
+  players: RoomPhasePlayerSnapshot[];
+  readySummary: RoomReadySummaryPayload;
+}
+
+export interface RoomUpdateGameStatePayload extends Partial<GameState> {
+  phase: GamePhase;
+  reason?: string;
+  finalResults?: Array<{ userId: number; score: number; placement: number }>;
+  finalRewards?: Record<string, unknown>;
+  snapshot?: RoomPhaseSnapshotPayload;
+}

--- a/src/game/constants/game.constant.ts
+++ b/src/game/constants/game.constant.ts
@@ -20,6 +20,7 @@ export const GAME_EVENTS = {
   LOADING_STARTED: 'game.loading.started',
   ROOM_READY_TOGGLE: 'room:readyToggle',
   ROOM_UPDATE_PLAYER: 'room:updatePlayer',
+  ROOM_UPDATE_READY_SUMMARY: 'room:updateReadySummary',
 } as const;
 
 export const GAME_DEFAULTS = {

--- a/src/game/drawing/drawing.gateway.ts
+++ b/src/game/drawing/drawing.gateway.ts
@@ -51,16 +51,21 @@ export class DrawingGateway {
 
     const res = await this.drawingService.submitDrawing({ roomId, userId });
 
+    if (res.shouldAdvance) {
+      await this.gameSessionService.advanceToEvaluating({ roomId, server: this.server });
+      return { ok: true, shouldAdvance: true };
+    }
+
     if (res.playerUpdate) {
       this.server
         .to(this.roomSocketRoom(roomId))
         .emit(GAME_EVENTS.ROOM_UPDATE_PLAYER, res.playerUpdate);
     }
 
-    if (res.shouldAdvance) {
-      await this.gameSessionService.advanceToEvaluating({ roomId, server: this.server });
-    }
+    this.server
+      .to(this.roomSocketRoom(roomId))
+      .emit(GAME_EVENTS.ROOM_UPDATE_READY_SUMMARY, res.readySummary);
 
-    return { ok: true, shouldAdvance: res.shouldAdvance };
+    return { ok: true, shouldAdvance: false };
   }
 }

--- a/src/game/drawing/drawing.service.ts
+++ b/src/game/drawing/drawing.service.ts
@@ -13,6 +13,8 @@ import { DRAWING_ERRORS } from './constants/drawing.constant';
 import { DrawingPhaseContextEntity } from './entities/drawing.entity';
 import { GameItemService } from '../item/game-item.service';
 import type { PhaseDisconnectResult } from '../interfaces/game-disconnect.interface';
+import { type RoomReadySummaryPayload } from 'src/game-state/interfaces/game-state-view.interface';
+import { getReadySummaryFromState } from '../utils/game-phase-ready.util';
 
 @Injectable()
 export class DrawingService {
@@ -48,6 +50,7 @@ export class DrawingService {
   async submitDrawing(params: { roomId: number; userId: number }): Promise<{
     shouldAdvance: boolean;
     playerUpdate?: { userId: number; changes: { isReady: true } };
+    readySummary: RoomReadySummaryPayload;
   }> {
     const { roomId, userId } = params;
 
@@ -63,10 +66,12 @@ export class DrawingService {
     if (!patched) throw new ConflictException(DRAWING_ERRORS.GAME_STATE_NOT_FOUND);
 
     const shouldAdvance = ctxEntity.isReadyToAdvance;
+    const readySummary = getReadySummaryFromState(patched);
 
     return {
       shouldAdvance,
       playerUpdate: becameReady ? { userId, changes: { isReady: true } } : undefined,
+      readySummary,
     };
   }
 

--- a/src/game/evaluation/evaluation.service.ts
+++ b/src/game/evaluation/evaluation.service.ts
@@ -15,6 +15,7 @@ import { wsError } from 'src/common/utils/ws-error.util';
 import { EVALUATION_VOTE } from './interfaces/evaluation-vote.interface';
 import type { IEvaluationVote } from './interfaces/evaluation-vote.interface';
 import type { PhaseDisconnectResult } from '../interfaces/game-disconnect.interface';
+import { type RoomReadySummaryPayload } from 'src/game-state/interfaces/game-state-view.interface';
 
 export const makeDrawingId = (matchId: number, roomMemberId: number, round: number) =>
   `${matchId}:${roomMemberId}:${round}`;
@@ -102,7 +103,7 @@ export class EvaluationService {
     roomId: number,
     gameState: GameState,
     userId: PlayerId,
-  ): Promise<{ isReady: boolean; allReady: boolean }> {
+  ): Promise<{ isReady: boolean; allReady: boolean; readySummary: RoomReadySummaryPayload }> {
     if (gameState.phase !== GamePhase.EVALUATING) {
       throw wsError(400, EVALUATION_ERRORS.INVALID_PHASE);
     }
@@ -136,8 +137,14 @@ export class EvaluationService {
 
     const patchedCtx = this.getEvaluatingContextOrNull(patched);
     const allReady = patchedCtx ? this.isAllReady(patchedCtx) : false;
+    const readySummary: RoomReadySummaryPayload = {
+      phase: GamePhase.EVALUATING,
+      readyCount: patchedCtx?.readyUserIds.length ?? 0,
+      totalCount: patchedCtx?.activeUserIds.length ?? 0,
+      allReady,
+    };
 
-    return { isReady: willBeReady, allReady };
+    return { isReady: willBeReady, allReady, readySummary };
   }
 
   async submitEvaluation(

--- a/src/game/game.gateway.ts
+++ b/src/game/game.gateway.ts
@@ -167,11 +167,16 @@ export class GameGateway implements IGameEventPublisher, OnGatewayConnection, On
 
     switch (gameState.phase) {
       case GamePhase.EVALUATING: {
-        const { isReady, allReady } = await this.evaluationService.toggleReady(
+        const { isReady, allReady, readySummary } = await this.evaluationService.toggleReady(
           roomId,
           gameState,
           userId,
         );
+
+        if (allReady) {
+          await this.gameSessionService.advanceToRoundSummary({ roomId, server: this.server });
+          return;
+        }
 
         const payload: RoomUpdatePlayerPayload = {
           userId,
@@ -179,10 +184,7 @@ export class GameGateway implements IGameEventPublisher, OnGatewayConnection, On
         };
 
         this.broadcastPlayerUpdate(roomId, payload);
-
-        if (allReady) {
-          await this.gameSessionService.advanceToRoundSummary({ roomId, server: this.server });
-        }
+        this.broadcastReadySummary(roomId, readySummary);
         return;
       }
 

--- a/src/game/game.gateway.ts
+++ b/src/game/game.gateway.ts
@@ -29,6 +29,11 @@ import { GameSessionService } from './session/game-session.service';
 import { RoundSummaryService } from './round-summary/round-summary.service';
 import { EvaluationService } from './evaluation/evaluation.service';
 import { RoomUpdatePlayerPayload } from './interfaces/game.interface';
+import {
+  RoomReadySummaryPayload,
+  RoomUpdateGameStatePayload,
+} from 'src/game-state/interfaces/game-state-view.interface';
+import { buildPhaseSnapshotFromState } from './utils/game-phase-ready.util';
 
 @UsePipes(
   new ValidationPipe({
@@ -173,7 +178,7 @@ export class GameGateway implements IGameEventPublisher, OnGatewayConnection, On
           changes: { isReady },
         };
 
-        this.server.to(`game:room:${roomId}`).emit(GAME_EVENTS.ROOM_UPDATE_PLAYER, payload);
+        this.broadcastPlayerUpdate(roomId, payload);
 
         if (allReady) {
           await this.gameSessionService.advanceToRoundSummary({ roomId, server: this.server });
@@ -192,9 +197,18 @@ export class GameGateway implements IGameEventPublisher, OnGatewayConnection, On
     }
   }
 
-  broadcastGameState(roomId: number, payload: any) {
+  broadcastGameState(roomId: number, payload: RoomUpdateGameStatePayload) {
     const roomKey = `game:room:${roomId}`;
-    this.server.to(roomKey).emit(GAME_EVENTS.ROOM_UPDATE_GAME_STATE, payload);
+    const normalized = this.withPhaseSnapshot(payload);
+    this.server.to(roomKey).emit(GAME_EVENTS.ROOM_UPDATE_GAME_STATE, normalized);
+  }
+
+  broadcastPlayerUpdate(roomId: number, payload: RoomUpdatePlayerPayload) {
+    this.server.to(`game:room:${roomId}`).emit(GAME_EVENTS.ROOM_UPDATE_PLAYER, payload);
+  }
+
+  broadcastReadySummary(roomId: number, payload: RoomReadySummaryPayload) {
+    this.server.to(`game:room:${roomId}`).emit(GAME_EVENTS.ROOM_UPDATE_READY_SUMMARY, payload);
   }
 
   emitThemeConfirmed(roomId: number, currentTheme: string) {
@@ -222,5 +236,19 @@ export class GameGateway implements IGameEventPublisher, OnGatewayConnection, On
     }
 
     this.logger.log(`Joined game room userId=${userId}, roomId=${roomId}, host=${isHost}`);
+  }
+
+  private withPhaseSnapshot(payload: RoomUpdateGameStatePayload): RoomUpdateGameStatePayload {
+    if (payload.snapshot) return payload;
+    if (!payload.roomMemberIdByUserId || !('phaseContext' in payload)) return payload;
+
+    return {
+      ...payload,
+      snapshot: buildPhaseSnapshotFromState({
+        phase: payload.phase,
+        phaseContext: payload.phaseContext ?? null,
+        roomMemberIdByUserId: payload.roomMemberIdByUserId,
+      }),
+    };
   }
 }

--- a/src/game/interfaces/game-disconnect.interface.ts
+++ b/src/game/interfaces/game-disconnect.interface.ts
@@ -1,9 +1,10 @@
 import { PhaseContext } from 'src/game-state/interfaces/game-state.interface';
+import { RoomUpdatePlayerPayload } from './game.interface';
 
 export interface PhaseDisconnectResult {
   nextPhaseContext: PhaseContext;
   shouldAdvance: boolean;
-  playerUpdate?: { userId: number; changes: { isConnected: boolean } };
+  playerUpdate?: RoomUpdatePlayerPayload;
   transitionPayload?: {
     selectedTopic?: string;
     selectedBy?: 'selector' | 'system';

--- a/src/game/interfaces/game-event-publisher.interfaces.ts
+++ b/src/game/interfaces/game-event-publisher.interfaces.ts
@@ -1,6 +1,14 @@
+import { type RoomUpdatePlayerPayload } from './game.interface';
+import {
+  type RoomReadySummaryPayload,
+  type RoomUpdateGameStatePayload,
+} from 'src/game-state/interfaces/game-state-view.interface';
+
 export const GAME_EVENT_PUBLISHER = Symbol('GAME_EVENT_PUBLISHER');
 
 export interface IGameEventPublisher {
-  broadcastGameState(roomId: number, payload: unknown): void;
+  broadcastGameState(roomId: number, payload: RoomUpdateGameStatePayload): void;
+  broadcastPlayerUpdate(roomId: number, payload: RoomUpdatePlayerPayload): void;
+  broadcastReadySummary(roomId: number, payload: RoomReadySummaryPayload): void;
   emitThemeConfirmed(roomId: number, theme: string): void;
 }

--- a/src/game/interfaces/game.interface.ts
+++ b/src/game/interfaces/game.interface.ts
@@ -1,6 +1,9 @@
+export interface RoomUpdatePlayerChanges {
+  isReady?: boolean;
+  isConnected?: boolean;
+}
+
 export interface RoomUpdatePlayerPayload {
   userId: number;
-  changes: {
-    isReady: boolean;
-  };
+  changes: RoomUpdatePlayerChanges;
 }

--- a/src/game/round-summary/round-summary.service.ts
+++ b/src/game/round-summary/round-summary.service.ts
@@ -10,6 +10,8 @@ import {
 import { GameSessionService } from '../session/game-session.service';
 import { GAME_EVENTS } from '../constants/game.constant';
 import { RoomUpdatePlayerPayload } from '../interfaces/game.interface';
+import { type RoomReadySummaryPayload } from 'src/game-state/interfaces/game-state-view.interface';
+import { getReadySummaryFromState } from '../utils/game-phase-ready.util';
 
 @Injectable()
 export class RoundSummaryService {
@@ -30,6 +32,10 @@ export class RoundSummaryService {
     };
 
     server.to(this.roomKey(roomId)).emit(GAME_EVENTS.ROOM_UPDATE_PLAYER, payload);
+  }
+
+  private broadcastReadySummary(server: Server, roomId: number, payload: RoomReadySummaryPayload) {
+    server.to(this.roomKey(roomId)).emit(GAME_EVENTS.ROOM_UPDATE_READY_SUMMARY, payload);
   }
 
   private getAllUserIdsFromState(state: GameState): number[] {
@@ -59,16 +65,18 @@ export class RoundSummaryService {
     });
     if (!patched) return;
 
-    this.broadcastPlayerReady(server, roomId, userId, isReady);
-
     const allUserIds = this.getAllUserIdsFromState(patched);
     const patchedCtx = patched.phaseContext;
     if (!patchedCtx || patchedCtx.kind !== GamePhase.ROUND_SUMMARY) return;
 
     const readySet = new Set(patchedCtx.readyUserIds ?? []);
     const allReady = allUserIds.length > 0 && allUserIds.every((id) => readySet.has(id));
-    if (!allReady) return;
+    if (allReady) {
+      await this.gameSessionService.advanceFromRoundSummary({ roomId, server });
+      return;
+    }
 
-    await this.gameSessionService.advanceFromRoundSummary({ roomId, server });
+    this.broadcastPlayerReady(server, roomId, userId, isReady);
+    this.broadcastReadySummary(server, roomId, getReadySummaryFromState(patched));
   }
 }

--- a/src/game/session/game-session.service.ts
+++ b/src/game/session/game-session.service.ts
@@ -25,6 +25,7 @@ import { MatchLifecycleService } from '../finished/match-lifecycle.service';
 import { FinishedReturnService } from '../finished/finished-return.service';
 import { FinalRewardsByUserId } from '../finished/types/finished.type';
 import { RoomUpdateGameStatePayload } from 'src/game-state/interfaces/game-state-view.interface';
+import { buildPhaseSnapshotFromState } from '../utils/game-phase-ready.util';
 
 type GameRemoteSocket = RemoteSocket<DefaultEventsMap, GameSocketData>;
 
@@ -278,7 +279,10 @@ export class GameSessionService {
 
     this.startEvaluatingPhaseTimer({ roomId, server });
 
-    this.eventPublisher.broadcastGameState(roomId, patched);
+    this.eventPublisher.broadcastGameState(roomId, {
+      ...patched,
+      snapshot: buildPhaseSnapshotFromState(patched),
+    });
 
     const matchId = state.matchId;
     const memberMap = state.roomMemberIdByUserId;

--- a/src/game/session/game-session.service.ts
+++ b/src/game/session/game-session.service.ts
@@ -24,6 +24,7 @@ import { EvaluationService } from '../evaluation/evaluation.service';
 import { MatchLifecycleService } from '../finished/match-lifecycle.service';
 import { FinishedReturnService } from '../finished/finished-return.service';
 import { FinalRewardsByUserId } from '../finished/types/finished.type';
+import { RoomUpdateGameStatePayload } from 'src/game-state/interfaces/game-state-view.interface';
 
 type GameRemoteSocket = RemoteSocket<DefaultEventsMap, GameSocketData>;
 
@@ -67,10 +68,14 @@ export class GameSessionService {
       this.clearPhaseTimer(roomId);
       await this.gameStateStore.delete(roomId);
 
-      server.to(this.roomSocketRoom(roomId)).emit(GAME_EVENTS.ROOM_UPDATE_GAME_STATE, {
+      const payload: RoomUpdateGameStatePayload = {
         phase: GamePhase.FINISHED,
+        endsAt: null,
+        phaseContext: null,
+        roomMemberIdByUserId: remainingMembers as Record<number, number>,
         reason: 'GAME_ABORTED_NOT_ENOUGH_PLAYERS',
-      });
+      };
+      this.eventPublisher.broadcastGameState(roomId, payload);
 
       this.logger.warn(
         `Game aborted: roomId=${roomId}, remaining=${remainingCount} after userId=${userId} left`,
@@ -116,9 +121,7 @@ export class GameSessionService {
 
     // ── 5. 후처리: 브로드캐스트 + Phase advance ──
     if (phaseResult?.playerUpdate) {
-      server
-        .to(this.roomSocketRoom(roomId))
-        .emit(GAME_EVENTS.ROOM_UPDATE_PLAYER, phaseResult.playerUpdate);
+      this.eventPublisher.broadcastPlayerUpdate(roomId, phaseResult.playerUpdate);
     }
 
     if (phaseResult?.shouldAdvance) {
@@ -275,11 +278,7 @@ export class GameSessionService {
 
     this.startEvaluatingPhaseTimer({ roomId, server });
 
-    server.to(this.roomSocketRoom(roomId)).emit(GAME_EVENTS.ROOM_UPDATE_GAME_STATE, {
-      phase: GamePhase.EVALUATING,
-      endsAt,
-      phaseContext: evaluatingContext,
-    });
+    this.eventPublisher.broadcastGameState(roomId, patched);
 
     const matchId = state.matchId;
     const memberMap = state.roomMemberIdByUserId;
@@ -346,11 +345,7 @@ export class GameSessionService {
         return;
       }
 
-      server.to(this.roomSocketRoom(roomId)).emit(GAME_EVENTS.ROOM_UPDATE_GAME_STATE, {
-        phase: patched.phase,
-        endsAt: patched.endsAt,
-        phaseContext: patched.phaseContext,
-      });
+      this.eventPublisher.broadcastGameState(roomId, patched);
 
       void this.startRoundSummaryPhaseTimer({ roomId, server });
     } catch (e) {

--- a/src/game/topic/topic.gateway.ts
+++ b/src/game/topic/topic.gateway.ts
@@ -12,13 +12,15 @@ import { TopicDto } from './dtos/requests/topic.dto';
 import type { GameSocket } from '../interfaces/gameSocket.interface';
 import { GameSessionService } from '../session/game-session.service';
 import {
-  GAME_STATE_STORE,
   GamePhase,
   GameState,
+  GAME_STATE_STORE,
   type IGameStateStore,
 } from 'src/game-state/interfaces/game-state.interface';
+import { RoomUpdateGameStatePayload } from 'src/game-state/interfaces/game-state-view.interface';
 import { requireRoomId, requireUserId } from '../utils/game-ws.util';
 import { GAME_EVENTS } from '../constants/game.constant';
+import { buildPhaseSnapshotFromState } from '../utils/game-phase-ready.util';
 
 @UseFilters(SocketExceptionFilter)
 @WebSocketGateway({
@@ -90,7 +92,13 @@ export class TopicGateway {
     }
 
     const next = await this.gameStateStore.patch(roomId, patch);
+    if (!next) return;
 
-    this.server.to(`game:room:${roomId}`).emit(GAME_EVENTS.ROOM_UPDATE_GAME_STATE, next);
+    const payload: RoomUpdateGameStatePayload = {
+      ...next,
+      snapshot: buildPhaseSnapshotFromState(next),
+    };
+
+    this.server.to(`game:room:${roomId}`).emit(GAME_EVENTS.ROOM_UPDATE_GAME_STATE, payload);
   }
 }

--- a/src/game/utils/game-phase-ready.util.ts
+++ b/src/game/utils/game-phase-ready.util.ts
@@ -1,0 +1,93 @@
+import { GamePhase, type GameState } from 'src/game-state/interfaces/game-state.interface';
+import {
+  type RoomPhaseSnapshotPayload,
+  type RoomReadySummaryPayload,
+} from 'src/game-state/interfaces/game-state-view.interface';
+
+type ReadySummarySource = Pick<GameState, 'phase' | 'phaseContext' | 'roomMemberIdByUserId'>;
+
+function isActiveReadyPhaseContext(
+  ctx: ReadySummarySource['phaseContext'],
+): ctx is Extract<
+  ReadySummarySource['phaseContext'],
+  { kind: GamePhase.DRAWING | GamePhase.EVALUATING }
+> {
+  return !!ctx && (ctx.kind === GamePhase.DRAWING || ctx.kind === GamePhase.EVALUATING);
+}
+
+function isRoundSummaryPhaseContext(
+  ctx: ReadySummarySource['phaseContext'],
+): ctx is Extract<ReadySummarySource['phaseContext'], { kind: GamePhase.ROUND_SUMMARY }> {
+  return !!ctx && ctx.kind === GamePhase.ROUND_SUMMARY;
+}
+
+function getReadyUserIds(state: ReadySummarySource): number[] {
+  const ctx = state.phaseContext;
+  if (isActiveReadyPhaseContext(ctx) || isRoundSummaryPhaseContext(ctx)) {
+    return ctx.readyUserIds ?? [];
+  }
+  return [];
+}
+
+export function getReadySummaryFromState(state: ReadySummarySource): RoomReadySummaryPayload {
+  switch (state.phase) {
+    case GamePhase.DRAWING:
+    case GamePhase.EVALUATING: {
+      const ctx = state.phaseContext;
+      if (!isActiveReadyPhaseContext(ctx)) {
+        return { phase: state.phase, readyCount: 0, totalCount: 0 };
+      }
+
+      return {
+        phase: state.phase,
+        readyCount: ctx.readyUserIds.length,
+        totalCount: ctx.activeUserIds.length,
+      };
+    }
+
+    case GamePhase.ROUND_SUMMARY: {
+      const ctx = state.phaseContext;
+      return {
+        phase: state.phase,
+        readyCount: isRoundSummaryPhaseContext(ctx) ? ctx.readyUserIds.length : 0,
+        totalCount: Object.keys(state.roomMemberIdByUserId ?? {}).length,
+      };
+    }
+
+    default:
+      return {
+        phase: state.phase,
+        readyCount: 0,
+        totalCount: 0,
+      };
+  }
+}
+
+function getPhaseReadyTargetUserIds(state: ReadySummarySource): number[] {
+  switch (state.phase) {
+    case GamePhase.DRAWING:
+    case GamePhase.EVALUATING: {
+      const ctx = state.phaseContext;
+      return isActiveReadyPhaseContext(ctx) ? [...ctx.activeUserIds] : [];
+    }
+
+    case GamePhase.ROUND_SUMMARY:
+      return Object.keys(state.roomMemberIdByUserId ?? {}).map(Number);
+
+    default:
+      return [];
+  }
+}
+
+export function buildPhaseSnapshotFromState(state: ReadySummarySource): RoomPhaseSnapshotPayload {
+  const readySet = new Set<number>(getReadyUserIds(state));
+  const targetUserIds = getPhaseReadyTargetUserIds(state);
+
+  return {
+    players: targetUserIds.map((userId) => ({
+      userId,
+      isReady: readySet.has(userId),
+    })),
+    readySummary: getReadySummaryFromState(state),
+  };
+}

--- a/src/game/utils/game-phase-ready.util.ts
+++ b/src/game/utils/game-phase-ready.util.ts
@@ -29,37 +29,31 @@ function getReadyUserIds(state: ReadySummarySource): number[] {
   return [];
 }
 
-export function getReadySummaryFromState(state: ReadySummarySource): RoomReadySummaryPayload {
+export function getReadyTargetCountByPhase(state: ReadySummarySource): number {
   switch (state.phase) {
     case GamePhase.DRAWING:
     case GamePhase.EVALUATING: {
       const ctx = state.phaseContext;
-      if (!isActiveReadyPhaseContext(ctx)) {
-        return { phase: state.phase, readyCount: 0, totalCount: 0 };
-      }
-
-      return {
-        phase: state.phase,
-        readyCount: ctx.readyUserIds.length,
-        totalCount: ctx.activeUserIds.length,
-      };
+      return isActiveReadyPhaseContext(ctx) ? ctx.activeUserIds.length : 0;
     }
 
-    case GamePhase.ROUND_SUMMARY: {
-      const ctx = state.phaseContext;
-      return {
-        phase: state.phase,
-        readyCount: isRoundSummaryPhaseContext(ctx) ? ctx.readyUserIds.length : 0,
-        totalCount: Object.keys(state.roomMemberIdByUserId ?? {}).length,
-      };
-    }
+    case GamePhase.ROUND_SUMMARY:
+      return Object.keys(state.roomMemberIdByUserId ?? {}).length;
 
     default:
-      return {
-        phase: state.phase,
-        readyCount: 0,
-        totalCount: 0,
-      };
+      return 0;
+  }
+}
+
+export function getReadySummaryFromState(state: ReadySummarySource): RoomReadySummaryPayload {
+  const readyCount = getReadyUserIds(state).length;
+  const totalCount = getReadyTargetCountByPhase(state);
+
+  return {
+    phase: state.phase,
+    readyCount,
+    totalCount,
+    allReady: totalCount > 0 && readyCount >= totalCount,
   }
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #5 

## 📝 작업 내용

- 준비/제출 완료 시 현재 phase 기준 완료 인원 집계를 전달하도록 room:updateReadySummary를 추가
- `room:updatePlayer`는 개별 유저 상태 변경만 담당
- 마지막 완료 시에는 별도 완료 broadcast 없이 즉시 **phase** 전환되도록 수정
- phase 전환 후에는 `room:updateGameState` **snapshot**으로 초기 상태를 한 번에 동기화하도록 변경
