### PR TITLE
game:join을 위한 서버 응답 통일

### DIFF
--- a/src/waiting/waiting.gateway.ts
+++ b/src/waiting/waiting.gateway.ts
@@ -173,7 +173,10 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
 
     this.server.to(`room:${body.roomId}`).emit(WAITING_EVENTS.ROOM_SYSTEM_MESSAGE, systemMessage);
 
-    client.emit(WAITING_EVENTS.ROOM_JOIN_SUCCESS, state);
+    client.emit(WAITING_EVENTS.ROOM_JOIN_SUCCESS, {
+      ...state,
+      roomId: body.roomId,
+    });
   }
 
   @SubscribeMessage(WAITING_EVENTS.ROOM_READY_TOGGLE)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #7 

## 📝 작업 내용

- `room:joinSuccess` + `roomId `= waiting 입장 확정의 source of truth를 URL이 아니라 서버 응답으로 맞추기 위한 수정
